### PR TITLE
chore: parametrize build_local.sh

### DIFF
--- a/build_local.sh
+++ b/build_local.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
-# Local compile baseline for the open T31 ISP driver.
+# Local compile baseline for the open Ingenic ISP driver.
 #
-# Builds driver/tx-isp-t31.ko out-of-tree against a thingino buildroot output.
-# No T31 output is built locally, so we compile against the T20L 3.10.14 tree:
-# same Ingenic kernel version + same mipsel uclibc toolchain, so it exercises
-# the identical 3.10 kernel API surface. The resulting .ko is a *compile
-# baseline*, not a loadable T31 artifact.
+# Builds the per-SoC driver from driver/<SOC>/ (default t31 -> tx-isp-t31.ko)
+# plus the shared diagnostic driver/tx_isp_trace.ko, out-of-tree against a
+# thingino buildroot output. If no matching SoC output is built locally, any
+# Ingenic 3.10.14 output works: same kernel version + same mipsel uclibc
+# toolchain exercise the identical 3.10 kernel API surface. The resulting .ko
+# is a *compile baseline*, not necessarily a loadable artifact for that SoC.
 #
 # Two gcc-15 diagnostics are relaxed because the source predates gcc-14's
 # promotion of these to hard errors (older Ingenic SDK toolchains only warned):
@@ -13,25 +14,57 @@
 #                                      external SDK symbol resolved at load time)
 #   - int-conversion
 # These are pre-existing latent issues, independent of file naming.
-set -e
+#
+# Parameters (all overridable via environment):
+#   TH      buildroot checkout            (default: ../thingino-firmware)
+#   ROOT    a single output/<...> dir     (default: first output with a toolchain)
+#   KDIR    kernel build tree             (default: $ROOT/build/linux-*)
+#   CROSS   cross-compile prefix          (default: mipsel-linux-)
+#   ARCH    target arch                   (default: mips)
+#   SOC     per-SoC driver subdir         (default: t31 -> driver/t31/)
+#
+# Examples:
+#   ./build_local.sh                       # autodetect everything, build modules
+#   SOC=t20 ./build_local.sh               # build driver/t20/ instead
+#   ROOT=/path/to/output/t31_foo ./build_local.sh
+#   TH=~/src/thingino-firmware ./build_local.sh clean
+set -euo pipefail
 
-TH="${TH:-/mnt/data/hardware/thingino-firmware}"
-ROOT="${ROOT:-$TH/output/master/xiaomi_xiaofang_t20l_jxf23_rtl8189ftv-3.10.14-uclibc}"
-KDIR="${KDIR:-$ROOT/build/linux-45a11a3318ee823a83536db737a8e1136ed766fd}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
 
-[ -x "$ROOT/host/bin/mipsel-linux-gcc" ] || { echo "toolchain missing: $ROOT/host/bin"; exit 1; }
-[ -f "$KDIR/Module.symvers" ]           || { echo "kernel tree not built: $KDIR"; exit 1; }
+TH="${TH:-$(cd "$HERE/.." && pwd)/thingino-firmware}"
+CROSS="${CROSS:-mipsel-linux-}"
+ARCH="${ARCH:-mips}"
+
+# ROOT: an output/<config> dir containing host/bin + build/linux-*.
+# If unset, pick the first one that ships a usable cross-gcc.
+if [ -z "${ROOT:-}" ]; then
+	[ -d "$TH/output" ] || { echo "buildroot output not found under: $TH/output (set TH=)"; exit 1; }
+	ROOT="$(find "$TH/output" -maxdepth 6 -path '*/host/bin/'"${CROSS}gcc" \
+	         -printf '%h\n' 2>/dev/null | sed 's#/host/bin$##' | sort | head -1)"
+	[ -n "$ROOT" ] || { echo "no ${CROSS}gcc toolchain found under $TH/output (set ROOT=)"; exit 1; }
+fi
+
+# KDIR: the built kernel tree inside ROOT.
+if [ -z "${KDIR:-}" ]; then
+	KDIR="$(find "$ROOT/build" -maxdepth 1 -type d -name 'linux-*' 2>/dev/null | sort | head -1)"
+fi
+
+[ -x "$ROOT/host/bin/${CROSS}gcc" ] || { echo "toolchain missing: $ROOT/host/bin/${CROSS}gcc"; exit 1; }
+[ -n "${KDIR:-}" ] && [ -f "$KDIR/Module.symvers" ] || { echo "kernel tree not built (no Module.symvers): ${KDIR:-<unset>}"; exit 1; }
+
+echo "ROOT=$ROOT"
+echo "KDIR=$KDIR"
 
 export PATH="$ROOT/host/bin:$PATH"
 
-HERE="$(cd "$(dirname "$0")" && pwd)"
 KCFLAGS="-Wno-error=implicit-function-declaration -Wno-error=int-conversion -Wno-error=implicit-int"
 GOAL="${1:-modules}"
 
 # Per-SoC ISP driver (driver/<SOC>/, default t31) -> tx-isp-<soc>.ko
 make -C "$KDIR" M="$HERE/driver/${SOC:-t31}" DIR=. \
-     ARCH=mips CROSS_COMPILE=mipsel-linux- KCFLAGS="$KCFLAGS" "$GOAL"
+     ARCH="$ARCH" CROSS_COMPILE="$CROSS" KCFLAGS="$KCFLAGS" "$GOAL"
 
 # Shared SoC-agnostic diagnostics (driver/) -> tx_isp_trace.ko
 make -C "$KDIR" M="$HERE/driver" DIR=. \
-     ARCH=mips CROSS_COMPILE=mipsel-linux- KCFLAGS="$KCFLAGS" "$GOAL"
+     ARCH="$ARCH" CROSS_COMPILE="$CROSS" KCFLAGS="$KCFLAGS" "$GOAL"


### PR DESCRIPTION
I had TH path hardcoded to my local mono repo. 

This makes the script parametrizable.   

If the thingino-firmware is located adjacent to this repo, it will work out of the box.